### PR TITLE
General temperature and gravity profiles

### DIFF
--- a/Model/Boussinesq/Shell/RTC/Explicit/ModelBackend.cpp
+++ b/Model/Boussinesq/Shell/RTC/Explicit/ModelBackend.cpp
@@ -976,6 +976,7 @@ std::vector<details::BlockDescription> ModelBackend::explicitLinearBlockBuilder(
                SparseSM::Chebyshev::LinearMap::I2Y3 i2r3(nNr, nNc, ri, ro);
                SparseSM::Chebyshev::LinearMap::I2 i2(nNr, nNc, ri, ro);
                bMat = -c1*ll1*i2r3.mat() -c2*ll1*i2.mat();
+            }
          }
 
          return bMat;

--- a/Model/Boussinesq/Shell/RTC/Explicit/ModelBackend.cpp
+++ b/Model/Boussinesq/Shell/RTC/Explicit/ModelBackend.cpp
@@ -899,7 +899,7 @@ std::vector<details::BlockDescription> ModelBackend::explicitLinearBlockBuilder(
          }
          else
          {
-            if(alpha == 1) // linear gravity
+            if(alpha == 100) // linear gravity
             {
                SparseSM::Chebyshev::LinearMap::I4Y4 spasm(nNr, nNc, ri, ro);
                bMat = Ra * spasm.mat();

--- a/Model/Boussinesq/Shell/RTC/Explicit/ModelBackend.cpp
+++ b/Model/Boussinesq/Shell/RTC/Explicit/ModelBackend.cpp
@@ -899,7 +899,7 @@ std::vector<details::BlockDescription> ModelBackend::explicitLinearBlockBuilder(
          }
          else
          {
-            if(alpha == 100) // linear gravity
+            if(alpha == 1) // linear gravity
             {
                SparseSM::Chebyshev::LinearMap::I4Y4 spasm(nNr, nNc, ri, ro);
                bMat = Ra * spasm.mat();

--- a/Model/Boussinesq/Shell/RTC/IRTCBackend.cpp
+++ b/Model/Boussinesq/Shell/RTC/IRTCBackend.cpp
@@ -30,6 +30,8 @@
 #include "QuICC/NonDimensional/CflInertial.hpp"
 #include "QuICC/NonDimensional/Ekman.hpp"
 #include "QuICC/NonDimensional/Heating.hpp"
+#include "QuICC/NonDimensional/Alpha.hpp"
+#include "QuICC/NonDimensional/Beta.hpp"
 #include "QuICC/NonDimensional/Lower1d.hpp"
 #include "QuICC/NonDimensional/Prandtl.hpp"
 #include "QuICC/NonDimensional/RRatio.hpp"
@@ -50,6 +52,7 @@
 #include "QuICC/SparseSM/Chebyshev/LinearMap/I2Y2SphLapl.hpp"
 #include "QuICC/SparseSM/Chebyshev/LinearMap/I2Y3.hpp"
 #include "QuICC/SparseSM/Chebyshev/LinearMap/I2Y3SphLapl.hpp"
+#include "QuICC/SparseSM/Chebyshev/LinearMap/I4Y1.hpp"
 #include "QuICC/SparseSM/Chebyshev/LinearMap/I4Y4.hpp"
 #include "QuICC/SparseSM/Chebyshev/LinearMap/I4Y4SphLapl.hpp"
 #include "QuICC/SparseSM/Chebyshev/LinearMap/I4Y4SphLapl2.hpp"
@@ -83,7 +86,8 @@ std::vector<std::string> IRTCBackend::paramNames() const
 {
    std::vector<std::string> names = {NonDimensional::Prandtl().tag(),
       NonDimensional::Rayleigh().tag(), NonDimensional::Ekman().tag(),
-      NonDimensional::Heating().tag(), NonDimensional::RRatio().tag()};
+      NonDimensional::Heating().tag(), NonDimensional::RRatio().tag(),
+      NonDimensional::Alpha().tag(), NonDimensional::Beta().tag()};
 
    return names;
 }
@@ -407,6 +411,8 @@ MHDFloat effectiveBg(const NonDimensional::NdMap& nds)
    auto ro = nds.find(NonDimensional::Upper1d::id())->second->value();
    auto rratio = nds.find(NonDimensional::RRatio::id())->second->value();
    auto heatingMode = nds.find(NonDimensional::Heating::id())->second->value();
+   auto beta = nds.find(NonDimensional::Beta::id())->second->value();
+
 
    if (ro == 1.0)
    {
@@ -421,6 +427,14 @@ MHDFloat effectiveBg(const NonDimensional::NdMap& nds)
    else if (heatingMode == 1)
    {
       effBg = ro * ro * rratio;
+   }
+   else if(heatingMode == 2)
+   {
+      effBg = 1.0;
+   }
+   else if(heatingMode == 3)
+   {
+      effBg = 1.0 / (1-rratio*rratio*rratio);
    }
 
    return effBg;

--- a/Model/Boussinesq/Shell/RTC/IRTCModel.cpp
+++ b/Model/Boussinesq/Shell/RTC/IRTCModel.cpp
@@ -46,6 +46,8 @@
 #include "QuICC/NonDimensional/CflInertial.hpp"
 #include "QuICC/NonDimensional/Ekman.hpp"
 #include "QuICC/NonDimensional/Heating.hpp"
+#include "QuICC/NonDimensional/Alpha.hpp"
+#include "QuICC/NonDimensional/Beta.hpp"
 #include "QuICC/NonDimensional/Lower1d.hpp"
 #include "QuICC/NonDimensional/Prandtl.hpp"
 #include "QuICC/NonDimensional/RRatio.hpp"

--- a/Model/Boussinesq/Shell/RTC/Momentum.cpp
+++ b/Model/Boussinesq/Shell/RTC/Momentum.cpp
@@ -76,8 +76,9 @@ void Momentum::setNLComponents()
 
    if (this->couplingInfo(FieldComponents::Spectral::POL).isSplitEquation())
    {
-      const auto alpha =
-            nds.find(NonDimensional::Alpha::id())->second->value();
+      //const auto alpha =
+      //      nds.find(NonDimensional::Alpha::id())->second->value();
+      const auto alpha = this->eqParams().nd(NonDimensional::Ekman::id()->second->value()
       if (alpha == 1)
       {
          this->addNLComponent(FieldComponents::Spectral::POL,

--- a/Model/Boussinesq/Shell/RTC/Momentum.cpp
+++ b/Model/Boussinesq/Shell/RTC/Momentum.cpp
@@ -78,7 +78,7 @@ void Momentum::setNLComponents()
    {
       //const auto alpha =
       //      nds.find(NonDimensional::Alpha::id())->second->value();
-      const auto alpha = this->eqParams().nd(NonDimensional::Ekman::id()->second->value()
+      MHDFloat alpha = this->eqParams().nd(NonDimensional::Alpha::id());
       if (alpha == 1)
       {
          this->addNLComponent(FieldComponents::Spectral::POL,

--- a/Model/Boussinesq/Shell/RTC/Momentum.cpp
+++ b/Model/Boussinesq/Shell/RTC/Momentum.cpp
@@ -12,11 +12,13 @@
 #include "Model/Boussinesq/Shell/RTC/Momentum.hpp"
 #include "Model/Boussinesq/Shell/RTC/MomentumKernel.hpp"
 #include "QuICC/NonDimensional/Ekman.hpp"
+#include "QuICC/NonDimensional/Alpha.hpp"
 #include "QuICC/PhysicalNames/Velocity.hpp"
 #include "QuICC/SolveTiming/Prognostic.hpp"
 #include "QuICC/SpatialScheme/ISpatialScheme.hpp"
 #include "QuICC/Transform/Path/I2CurlNl.hpp"
 #include "QuICC/Transform/Path/NegI2CurlCurlNl.hpp"
+#include "QuICC/Transform/Path/NegI2rCurlCurlNl.hpp"
 #include "QuICC/Transform/Path/NegI4CurlCurlNl.hpp"
 
 namespace QuICC {
@@ -74,8 +76,19 @@ void Momentum::setNLComponents()
 
    if (this->couplingInfo(FieldComponents::Spectral::POL).isSplitEquation())
    {
-      this->addNLComponent(FieldComponents::Spectral::POL,
+      const auto alpha =
+            nds.find(NonDimensional::Alpha::id())->second->value();
+      if (alpha == 1)
+      {
+         this->addNLComponent(FieldComponents::Spectral::POL,
          Transform::Path::NegI2CurlCurlNl::id());
+      }
+      else
+      {
+         this->addNLComponent(FieldComponents::Spectral::POL,
+         Transform::Path::NegI2rCurlCurlNl::id());
+      }
+      
    }
    else
    {

--- a/Python/linear_stability/boussinesq/shell/rtc/trace_marginal.py
+++ b/Python/linear_stability/boussinesq/shell/rtc/trace_marginal.py
@@ -18,17 +18,17 @@ mc = None
 rescale = False
 
 # SF/SF, FT/FT, differential heating, small gap
-#bc_vel = 1; bc_temp = 0; heating = 1; rratio = 0.99; Pr = 1; rescale = True
+#bc_vel = 1; bc_temp = 0; heating = 1; alpha=1; beta=1; rratio = 0.99; Pr = 1; rescale = True
 #res = [64, 92, 0]
 #Ta = 1e12; Ek = Ta**-0.5; Rac = 7.4758215298779; mc = 245
 
 # SF/SF, FT/FT, differential heating
-#bc_vel = 1; bc_temp = 0; heating = 1; rratio = 0.35; Pr = 1; rescale = True
+#bc_vel = 1; bc_temp = 0; heating = 1; alpha=1; beta=1; rratio = 0.35; Pr = 1; rescale = True
 #res = [96, 96, 0]
 #Ta = 1e10; Ek = Ta**-0.5; Rac = 40; mc = 10
 
 # SF/SF, FT/FT, internal heating
-#bc_vel = 1; bc_temp = 0; heating = 0; rratio = 0.35; Pr = 1; rescale = True
+#bc_vel = 1; bc_temp = 0; heating = 0; alpha=1; beta=1; rratio = 0.35; Pr = 1; rescale = True
 #Ta = 1e6; Ek = Ta**-0.5
 #res = [32, 32, 0]
 #Ta = 1e7; Ek = Ta**-0.5
@@ -57,7 +57,7 @@ rescale = False
 #res = [1024, 384, 0]
 
 # NS/NS, FT/FT, internal heating
-bc_vel = 0; bc_temp = 0; heating = 0; rratio = 0.35; Pr = 1; rescale = True
+bc_vel = 0; bc_temp = 0; heating = 0; alpha=1; beta=1; rratio = 0.35; Pr = 1; rescale = True
 #Ta = 1e6; Ek = Ta**-0.5
 #res = [32, 32, 0]
 #Ta = 1e7; Ek = Ta**-0.5
@@ -86,7 +86,7 @@ res = [48, 48, 0]
 #res = [1024, 1024, 0]
 
 # NS/NS, FT/FT, differential heating
-#bc_vel = 0; bc_temp = 0; heating = 1; rratio = 0.35; Pr = 1; rescale = True
+#bc_vel = 0; bc_temp = 0; heating = 1; alpha=1; beta=1; rratio = 0.35; Pr = 1; rescale = True
 #Ta = 1e6; Ek = Ta**-0.5
 #res = [32, 32, 0]
 #Ta = 1e7; Ek = Ta**-0.5
@@ -115,7 +115,7 @@ res = [48, 48, 0]
 #res = [1024, 1024, 0]
 
 # NS/NS, FT/FT, internal heating, ri/ro =  0.4
-#bc_vel = 0; bc_temp = 0; heating = 0; rratio = 0.4; Pr = 1; rescale = False
+#bc_vel = 0; bc_temp = 0; heating = 0; alpha=1; beta=1; rratio = 0.4; Pr = 1; rescale = False
 #Ek = 3e-3; Rac = 27.254; mc = 4
 #res = [32, 32, 0]
 #Ek = 1e-3; Rac = 23.7692; mc = 5
@@ -128,12 +128,19 @@ res = [48, 48, 0]
 #res = [64, 64, 0]
 
 # NS/NS, FT/FT, internal heating, ri/ro =  0.2
-#bc_vel = 0; bc_temp = 0; heating = 0; rratio = 0.2; Pr = 1; rescale = False
+#bc_vel = 0; bc_temp = 0; heating = 0; alpha=1; beta=1; rratio = 0.2; Pr = 1; rescale = False
 #Ek = 1e-4; Rac = 46.482; mc = 6
 
 # NS/NS, FT/FT, internal heating, ri/ro =  0.6
-#bc_vel = 0; bc_temp = 0; heating = 0; rratio = 0.6; Pr = 1; rescale = False
+#bc_vel = 0; bc_temp = 0; heating = 0; alpha=1; beta=1; rratio = 0.6; Pr = 1; rescale = False
 #Ek = 1e-4; Rac = 27.0031; mc = 18
+
+# NS/NS, FT/FT, heating=3, ri/ro=0.35
+#bc_vel = 0; bc_temp = 1
+#heating = 3; alpha=0.5; beta=0.1
+#rratio = 0.35; Pr = 0.1; rescale = False
+#Ek = 0.5*1e-3;  Rac = 10; mc = 1
+#res = [32, 32, 0]
 
 # Convert Ekman to Taylor number
 Ta = Ek**-2
@@ -154,7 +161,7 @@ if rescale:
     Ek = (Ta*(1.0-rratio)**4)**-0.5
 else:
     Ek = Ta**-0.5
-eq_params = {'ekman':Ek, 'prandtl':Pr, 'rayleigh':Ra, 'r_ratio':rratio, 'heating':heating}
+eq_params = {'ekman':Ek, 'prandtl':Pr, 'rayleigh':Ra, 'r_ratio':rratio, 'heating':heating, 'beta':beta, 'alpha':alpha }
 eq_params.update(model.automatic_parameters(eq_params))
 bcs = {'bcType':model.SOLVER_HAS_BC, 'velocity':bc_vel, 'temperature':bc_temp}
 

--- a/Python/linear_stability/boussinesq/shell/rtc/trace_marginal.py
+++ b/Python/linear_stability/boussinesq/shell/rtc/trace_marginal.py
@@ -57,13 +57,13 @@ rescale = False
 #res = [1024, 384, 0]
 
 # NS/NS, FT/FT, internal heating
-bc_vel = 0; bc_temp = 0; heating = 0; alpha=1; beta=1; rratio = 0.35; Pr = 1; rescale = True
+#bc_vel = 0; bc_temp = 0; heating = 0; alpha=1; beta=1; rratio = 0.35; Pr = 1; rescale = True
 #Ta = 1e6; Ek = Ta**-0.5
 #res = [32, 32, 0]
 #Ta = 1e7; Ek = Ta**-0.5
 #res = [32, 32, 0]
-Ta = 1e8; Ek = Ta**-0.5; Rac = 31.534088376364; mc = 6
-res = [48, 48, 0]
+#Ta = 1e8; Ek = Ta**-0.5; Rac = 31.534088376364; mc = 6
+#res = [48, 48, 0]
 #Ta = 1e9; Ek = Ta**-0.5; Rac = 42.219154540505; mc = 9
 #res = [48, 48, 0]
 #Ta = 1e10; Ek = Ta**-0.5; Rac = 59.124359856967; mc = 13
@@ -136,11 +136,11 @@ res = [48, 48, 0]
 #Ek = 1e-4; Rac = 27.0031; mc = 18
 
 # NS/NS, FT/FT, heating=3, ri/ro=0.35
-#bc_vel = 0; bc_temp = 1
-#heating = 3; alpha=0.5; beta=0.1
-#rratio = 0.35; Pr = 0.1; rescale = False
-#Ek = 0.5*1e-3;  Rac = 10; mc = 1
-#res = [32, 32, 0]
+bc_vel = 0; bc_temp = 1
+heating = 3; alpha=0.5; beta=0.1
+rratio = 0.35; Pr = 0.1; rescale = False
+Ek = 0.5*1e-3;  Rac = 10; mc = 1
+res = [32, 32, 0]
 
 # Convert Ekman to Taylor number
 Ta = Ek**-2

--- a/Python/quicc_solver/model/boussinesq/shell/rtc/explicit/physical_model.py
+++ b/Python/quicc_solver/model/boussinesq/shell/rtc/explicit/physical_model.py
@@ -180,12 +180,16 @@ class PhysicalModel(base_model.BaseModel):
                         bc = {0:-22, 'rt':0}
                     elif field_col == ("velocity","pol"):
                         bc = {0:-41, 'rt':0}
+                    elif field_col == ("temperature",""):
+                        bc = {0:-21, 'rt':0}
 
                 else:
                     if field_row == ("velocity","tor") and field_col == ("velocity","tor"):
                         bc = {0:22}
                     elif field_row == ("velocity","pol") and field_col == ("velocity","pol"):
                         bc = {0:41}
+                    elif field_row == ("temperature","") and field_col == ("temperature",""):
+                            bc = {0:21}
 
             # Set LHS galerkin restriction
             if self.use_galerkin:

--- a/Python/quicc_solver/model/boussinesq/shell/rtc/explicit/physical_model.py
+++ b/Python/quicc_solver/model/boussinesq/shell/rtc/explicit/physical_model.py
@@ -23,7 +23,14 @@ class PhysicalModel(base_model.BaseModel):
     def nondimensional_parameters(self):
         """Get the list of nondimensional parameters"""
 
-        return ["ekman", "prandtl", "rayleigh", "r_ratio", "heating"]
+        return ["ekman", "prandtl", "rayleigh", "r_ratio", "heating","alpha","beta"]
+
+        # alpha = 1 yields a linear gravity in r, whereas alpha !=1 leads to a alpha*r+(1-alpha)/r^2 type gravity profile
+        # beta = 1 is for pure internal heating, beta =0 is for pure differential heating
+        # heating=0: internal heating;
+        # heating=1: differential heating;
+        # heating=2: differential heating + internal heating (proportional to r)
+        # heating=3: differential heating + internal heating (general form)
 
     def automatic_parameters(self, eq_params):
         """Extend parameters with automatically computable values"""
@@ -236,13 +243,28 @@ class PhysicalModel(base_model.BaseModel):
         mat = None
         bc = self.convert_bc(eq_params,eigs,bcs,field_row,field_col)
         if field_row == ("velocity","pol") and field_col == ("temperature",""):
-            mat = geo.i4r4(res[0], ri, ro, bc, Ra_eff)
+            alpha = eq_params['alpha']
+            c1 = Ra_eff * alpha
+            c2 = Ra_eff *(1-alpha) * ro**3
+            #mat = geo.i4r4(res[0], ri, ro, bc, Ra_eff)
+            mat = geo.i4r4(res[0], ri, ro, bc, c1) + geo.i4r1(res[0], ri, ro, bc, c2)
 
         elif field_row == ("temperature","") and field_col == ("velocity","pol"):
             if eq_params["heating"] == 0:
                 mat = geo.i2r2(res[0], ri, ro, bc, -bg_eff*l*(l+1.0))
-            else:
+            elif eq_params["heating"] == 1:
                 mat = geo.i2(res[0], ri, ro, bc, -bg_eff*l*(l+1.0))
+            elif eq_params["heating"] == 2 or eq_params["heating"] == 3:
+                beta = eq_params['beta']
+                # assumes length-scale is the depth of the shell
+                c1 = beta*bg_eff/ro # internal heating contribution
+                c2 = ro**2*(1-beta*bg_eff) # differential heating contribution
+                if beta==1/bg_eff: # similar to heating=0
+                    mat = geo.i2r2(res[0], ri, ro, bc, -c1*l*(l+1.0))
+                elif beta==0: # similar to heating=1
+                    mat = geo.i2(res[0], ri, ro, bc, -c2*l*(l+1.0))
+                else:
+                    mat = geo.i2r3(res[0], ri, ro, bc, -c1*l*(l+1.0)) + geo.i2(res[0], ri, ro, bc, -c2*l*(l+1.0))
 
         if mat is None:
             raise RuntimeError("Equations are not setup properly!")
@@ -254,13 +276,21 @@ class PhysicalModel(base_model.BaseModel):
 
         ri, ro = (self.automatic_parameters(eq_params)['lower1d'], self.automatic_parameters(eq_params)['upper1d'])
 
+        Ra_eff, bg_eff = self.nondimensional_factors(eq_params)
+
         mat = None
         bc = self.convert_bc(eq_params,eigs,bcs,field_row,field_col)
         if field_row == ("temperature","") and field_col == field_row:
             if eq_params["heating"] == 0:
                 mat = geo.i2r2(res[0], ri, ro, bc)
-            else:
+            elif eq_params["heating"] == 1:
                 mat = geo.i2r3(res[0], ri, ro, bc)
+            elif eq_params["heating"] == 2 or eq_params["heating"] == 3:
+                beta = eq_params['beta']
+                if beta==1/bg_eff: # same as for heating=0
+                    mat = geo.i2r2(res[0], ri, ro, bc)
+                else:
+                    mat = geo.i2r3(res[0], ri, ro, bc)
 
         if mat is None:
             raise RuntimeError("Equations are not setup properly!")
@@ -277,6 +307,8 @@ class PhysicalModel(base_model.BaseModel):
 
         ri, ro = (self.automatic_parameters(eq_params)['lower1d'], self.automatic_parameters(eq_params)['upper1d'])
 
+        Ra_eff, bg_eff = self.nondimensional_factors(eq_params)
+
         mat = None
         bc = self.convert_bc(eq_params,eigs,bcs,field_row,field_col)
         if field_row == ("velocity","tor") and field_col == field_row:
@@ -288,8 +320,14 @@ class PhysicalModel(base_model.BaseModel):
         elif field_row == ("temperature","") and field_col == field_row:
             if eq_params["heating"] == 0:
                 mat = geo.i2r2lapl(res[0], ri, ro, l, bc, 1.0/Pr)
-            else:
+            elif eq_params["heating"] == 1:
                 mat = geo.i2r3lapl(res[0], ri, ro, l, bc, 1.0/Pr)
+            elif eq_params["heating"] == 2 or eq_params["heating"] == 3:
+                    beta = eq_params['beta']
+                    if beta==1/bg_eff: # same as for heating=0
+                        mat = geo.i2r2lapl(res[0], ri, ro, l, bc, 1.0/Pr)
+                    else:
+                         mat = geo.i2r3lapl(res[0], ri, ro, l, bc, 1.0/Pr)
 
         if mat is None:
             raise RuntimeError("Equations are not setup properly!")
@@ -304,6 +342,8 @@ class PhysicalModel(base_model.BaseModel):
 
         ri, ro = (self.automatic_parameters(eq_params)['lower1d'], self.automatic_parameters(eq_params)['upper1d'])
 
+        Ra_eff, bg_eff = self.nondimensional_factors(eq_params)
+        
         mat = None
         bc = self.convert_bc(eq_params,eigs,bcs,field_row,field_row)
         if field_row == ("velocity","tor"):
@@ -315,8 +355,14 @@ class PhysicalModel(base_model.BaseModel):
         elif field_row == ("temperature",""):
             if eq_params["heating"] == 0:
                 mat = geo.i2r2(res[0], ri, ro, bc)
-            else:
+            elif eq_params["heating"] == 1:
                 mat = geo.i2r3(res[0], ri, ro, bc)
+            elif eq_params["heating"] == 2 or eq_params["heating"] == 3:
+                beta = eq_params['beta']
+                if beta == 1/bg_eff: # same as for heating=0
+                    mat = geo.i2r2(res[0], ri, ro, bc)
+                else:
+                    mat = geo.i2r3(res[0], ri, ro, bc)
 
         if mat is None:
             raise RuntimeError("Equations are not setup properly!")
@@ -361,5 +407,11 @@ class PhysicalModel(base_model.BaseModel):
             # (R_o - R_i) rescaling
             Ra_eff = (Ra*T/ro)
             bg_eff = ro**2*rratio
+        elif eq_params['heating'] == 2:
+            Ra_eff = (Ra*T/ro)
+            bg_eff = 1
+        elif eq_params['heating'] == 3:
+            Ra_eff = (Ra*T/ro)
+            bg_eff = 1/(1-rratio**3)
 
         return (Ra_eff, bg_eff)

--- a/Python/quicc_solver/model/boussinesq/shell/rtc/implicit/physical_model.py
+++ b/Python/quicc_solver/model/boussinesq/shell/rtc/implicit/physical_model.py
@@ -208,7 +208,7 @@ class PhysicalModel(base_model.BaseModel):
                     elif field_row == ("velocity","pol") and field_col == ("velocity","pol"):
                         bc = {0:41}
                     elif field_row == ("temperature","") and field_col == ("temperature",""):
-                            bc = {0:21}
+                        bc = {0:21}
 
             # Set LHS galerkin restriction
             if self.use_galerkin:

--- a/Readme.md
+++ b/Readme.md
@@ -41,3 +41,43 @@ The system is solved using a Toroidal/Poloidal decomposition of the velocity
 $$
 {\bf u} = \nabla\times T {\bf r} + \nabla\times\nabla\times P {\bf r} .
 $$
+
+
+## General background profiles
+
+**The following functionalities are currently implemented only for the Explicit models, and not for the SplitEqaution formalism.**
+
+The parameters $\alpha$ (`alpha`) and $\beta$ (`beta`) can be used to set up general gravity and background temperature profiles. The following are currently implemented:
+
+### Gravity:
+The following general gravity profile is implemented:
+
+$$
+{\bf g} = -g_o\left[\left(\frac{r}{r_o}\right)\alpha + \left(\frac{r_o}{r}\right)^2(1-\alpha)\right]\hat{\bf r}
+$$
+
+where, with $\alpha=1$ a linear profile is obtained, adequate for an inner core of the same density as the outer core.
+
+**This is the feature not implemented in the SplitEqaution formalism.**
+
+### Temperature:
+
+General background temperature profiles, $T$, containing a mix of both internal and differential heating are implemented.
+
+There are two options, chosed via the parameter `heating`:
+
+- `heating`=2 implements a purely linear internal heating component, resulting in:
+
+$$
+T = T'_o\left[\left(\frac{r}{r_o}\right)\beta + \left(\frac{r_o}{r}\right)^2(1-\beta)\right]
+$$
+
+- `heating`=3 implements a fully general form for the  internal heating component, resulting in:
+
+$$
+\frac{dT}{dr} = T'_o\left[\frac{1}{1-\chi^3}\left(\frac{r}{r_o}\right)\beta + \left(\frac{r_o}{r}\right)^2\left(1-\frac{\beta}{1-\chi^3}\right)\right]
+$$
+
+In both formulations, `heating`=1 is the pure internal heating case, and `heating`=0 is the differential heating case.
+
+In both cases, tempreature is nondimensionalised via $T'_o$, the temperature gradient at the outer boundary, $r_o$. In the above definition of the Rayleigh number, therefore: $\mathcal{T} = D T'_o$.

--- a/Readme.md
+++ b/Readme.md
@@ -45,8 +45,6 @@ $$
 
 ## General background profiles
 
-**The following functionalities are currently implemented only for the Explicit models, and not for the SplitEqaution formalism.**
-
 The parameters $\alpha$ (`alpha`) and $\beta$ (`beta`) can be used to set up general gravity and background temperature profiles. The following are currently implemented:
 
 ### Gravity:
@@ -57,8 +55,6 @@ $$
 $$
 
 where, with $\alpha=1$ a linear profile is obtained, adequate for an inner core of the same density as the outer core.
-
-**This is the feature not implemented in the SplitEqaution formalism.**
 
 ### Temperature:
 


### PR DESCRIPTION
More general temperature and gravity profiles can now be used. Both gravity and background temperature now include a sum of a linear term in r and a term proportional to 1/r^2 (see the updated Readme for details).

The new profiles are considered by setting heating to 2 or 3 in the parameter file. If heating is 0 or 1, the current implementation (pure internal or differential heating), is invoked. These latter cases have not been modified and should be run as before (this has been tested). 

in the parameter.cfg now two new paremeters appear: alpha and beta, which control the exact shape of the background profiles. These are not used by the model if heating = 0, 1 and their value should be inconsequential in these cases.